### PR TITLE
Remove proc_evaluate dependency and bump version

### DIFF
--- a/lib/omniauth/strategies/azure_active_directory_b2c.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c.rb
@@ -1,5 +1,4 @@
 require 'omniauth'
-require 'proc_evaluate'
 
 require_relative 'azure_active_directory_b2c/authentication_request.rb'
 require_relative 'azure_active_directory_b2c/authentication_response.rb'
@@ -14,8 +13,6 @@ module OmniAuth
     class AzureActiveDirectoryB2C
 
       include OmniAuth::Strategy
-
-      using ProcEvaluate # adds the `evaluate` refinement method to Object and Proc instances
 
       #########################################
       # Error definitions
@@ -59,7 +56,7 @@ module OmniAuth
       end
 
       def redirect_uri
-        @redirect_uri ||= options.redirect_uri.evaluate(self) || (raise MissingOptionError, '`redirect_uri` not defined')
+        @redirect_uri ||= options.redirect_uri || (raise MissingOptionError, '`redirect_uri` not defined')
       end
 
       def setup_phase

--- a/lib/omniauth/strategies/azure_active_directory_b2c/version.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/version.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module Strategies
     class AzureActiveDirectoryB2C
 
-      VERSION = '0.2.1'
+      VERSION = '0.2.2'
 
     end
   end

--- a/omniauth-azure_active_directory_b2c.gemspec
+++ b/omniauth-azure_active_directory_b2c.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth', '~> 2.0'
   spec.add_dependency 'openid_connect', '~> 1.1'
-  spec.add_dependency 'proc_evaluate', '~> 1.0'
 end


### PR DESCRIPTION
The gem proc_evaluate is not compatible with ruby 3 and seems that will not be ported. We don't make use of this functionality and if needed should not be hard to implement (not at transparent as the gem)